### PR TITLE
Fixed typo in cluster.sh

### DIFF
--- a/cluster/cluster.sh
+++ b/cluster/cluster.sh
@@ -185,7 +185,7 @@ down_workers ()
     printf "\n%s\n" "$HEADER"
     echo "$ docker-compose stop worker && docker-compose rm -f worker"
     printf "\n"
-    docker-compose stop master && docker-compose rm -f master
+    docker-compose stop worker && docker-compose rm -f worker
 }
 
 list ()


### PR DESCRIPTION
Method down_workers contains the same command as down_master method: "docker-compose stop master && docker-compose rm -f master"