### PR TITLE
Added fix to cluster login taking only first row from awk

### DIFF
--- a/cluster/cluster.sh
+++ b/cluster/cluster.sh
@@ -201,7 +201,7 @@ list ()
 exec_on_mpi_master_container ()
 {
     # shellcheck disable=SC2046
-    docker exec -it -u mpi $(docker-compose ps | grep 'master'| awk '{print $1}') "$@"
+    docker exec -it -u mpi $(docker-compose ps | grep 'master'| awk 'NR==1{print $1}') "$@"
 }
 
 prompt_ready ()
@@ -359,7 +359,7 @@ elif [ $COMMAND_RELOAD -eq 1 ]; then
     show_instruction
 
 elif [ $COMMAND_LOGIN -eq 1 ]; then
-    exec_on_mpi_master_container ash
+    exec_on_mpi_master_container /bin/sh
 
 elif [ $COMMAND_EXEC -eq 1 ]; then
     exec_on_mpi_master_container ash -c "${SHELL_COMMAND}"


### PR DESCRIPTION
`cluster login` fails with error: 

> OCI runtime exec failed: exec failed: container_linux.go:344: starting container
>  process caused "exec: \"role=master\": executable file not found in $PATH": unknown

This is due to the awk command in `exec_on_mpi_master_container` returning two lines instead of one:
`docker-compose ps | grep 'master'|
awk '{print $1}'`
> cluster_master_1
> role=master

Added fix to only return one line from awk.