### PR TITLE
Fix detection of external hosts

### DIFF
--- a/onbuild/Dockerfile
+++ b/onbuild/Dockerfile
@@ -2,7 +2,8 @@ FROM nlknguyen/alpine-mpich:latest
 
 USER root
 
-RUN apk add --no-cache openssh 
+# bind-tools gives us 'dig'
+RUN apk add --no-cache openssh bind-tools
 
 # # ------------------------------------------------------------
 # # Utility shell scripts

--- a/onbuild/get_hosts
+++ b/onbuild/get_hosts
@@ -4,5 +4,9 @@
 # shellcheck disable=SC1091
 . /etc/opt/service_names
 
-( netstat -t | grep ESTABLISHED | awk '{print $5}' | grep "$MPI_WORKER_SERVICE_NAME" | cut -d: -f1  \
-& getent hosts "$MPI_MASTER_SERVICE_NAME" | cut -d' ' -f1 ) | sort -u
+( dig +nocmd +nocomments +noquestion +nostats "$MPI_MASTER_SERVICE_NAME" | \
+  awk '{print $5}' \
+& dig +nocmd +nocomments +noquestion +nostats "$MPI_WORKER_SERVICE_NAME" | \
+  awk '{print $5}' \
+& dig +nocmd +nocomments +noquestion +nostats "tasks.$MPI_WORKER_SERVICE_NAME"|\
+  awk '{print $5}' ) | sort -u


### PR DESCRIPTION
In swarm mode, containers running on other hosts are not always detected by `netstat -t`. This fix uses `dig` instead, based on https://stackoverflow.com/questions/49446165/how-to-get-all-ip-addresses-on-a-docker-network