### PR TITLE
fixed problem with docker-compose scale not existing anymore

### DIFF
--- a/cluster/cluster.sh
+++ b/cluster/cluster.sh
@@ -164,9 +164,9 @@ up_workers ()
     printf "\\n%s\\n" "$HEADER"
 
     NUM_WORKER=$((SIZE - 1))
-    echo "$ docker-compose scale worker=$NUM_WORKER"
+    echo "$ docker-compose up --scale worker=$NUM_WORKER"
     printf "\\n"
-    docker-compose scale worker=${NUM_WORKER}
+    docker-compose up --scale worker=${NUM_WORKER}
 }
 
 down_master ()


### PR DESCRIPTION
Hi!

```
docker-compose scale worker=5 
```

Does not exist anymore, new option seems to be:

```
docker-compose up --scale worker=5
```

Hope it change is useful

Cheers!