### PR TITLE
Fixing base Docker image

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine:3.19
 # In case the main package repositories are down, use the alternative base image:
 # FROM gliderlabs/alpine:3.4
 # Updated by nbp - adding ca-certs etc.
@@ -8,7 +8,11 @@ MAINTAINER Nikyle Nguyen <NLKNguyen@MSN.com>
 ARG REQUIRE="sudo build-base"
 RUN apk update && apk upgrade \
       && apk add --no-cache ${REQUIRE}
-RUN apk update && apk add ca-certificates && update-ca-certificates && apk add openssl
+RUN apk update\
+      && apk add ca-certificates wget && update-ca-certificates \
+      && apk add openssl \
+      && apk add perl \
+      && apk add python3 \
 
 #### INSTALL MPICH ####
 # Source is available at http://www.mpich.org/static/downloads/

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -13,6 +13,8 @@ RUN apk update\
       && apk add openssl \
       && apk add perl \
       && apk add python3 \
+      && apk add linux-headers \
+      && apk add nano 
 
 #### INSTALL MPICH ####
 # Source is available at http://www.mpich.org/static/downloads/
@@ -21,8 +23,8 @@ RUN apk update\
 # See installation guide of target MPICH version
 # Ex: http://www.mpich.org/static/downloads/3.2/mpich-3.2-installguide.pdf
 # These options are passed to the steps below
-ARG MPICH_VERSION="3.2"
-ARG MPICH_CONFIGURE_OPTIONS="--disable-fortran"
+ARG MPICH_VERSION="3.3"
+ARG MPICH_CONFIGURE_OPTIONS="--disable-fortran --with-device=ch3 --disable-f77 --disable-fc"
 ARG MPICH_MAKE_OPTIONS
 
 # Download, build, and install MPICH

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -14,7 +14,8 @@ RUN apk update\
       && apk add perl \
       && apk add python3 \
       && apk add linux-headers \
-      && apk add nano 
+      && apk add nano \
+      && apk add bash 
 
 #### INSTALL MPICH ####
 # Source is available at http://www.mpich.org/static/downloads/
@@ -23,7 +24,7 @@ RUN apk update\
 # See installation guide of target MPICH version
 # Ex: http://www.mpich.org/static/downloads/3.2/mpich-3.2-installguide.pdf
 # These options are passed to the steps below
-ARG MPICH_VERSION="3.3"
+ARG MPICH_VERSION="3.4"
 ARG MPICH_CONFIGURE_OPTIONS="--disable-fortran --with-device=ch3 --disable-f77 --disable-fc"
 ARG MPICH_MAKE_OPTIONS
 
@@ -42,7 +43,7 @@ RUN wget http://www.mpich.org/static/downloads/${MPICH_VERSION}/mpich-${MPICH_VE
 RUN mkdir /tmp/mpich-test
 WORKDIR /tmp/mpich-test
 COPY mpich-test .
-RUN sh test.sh
+RUN bash test.sh
 RUN rm -rf /tmp/mpich-test
 
 


### PR DESCRIPTION
I have:

- Updated the alpine image from 3.4 to latest 3.19.
- Fixed certificates for wget, fixing #18 
- Added some more dependencies as linux-headers, needed for compiling MPICH versions > 3.2, fixing #15.
- Updated the compiling flags of MPICH for being able to compile MPICH versions from 3.3 to 4.0.3.

I had to install nano, because get_hosts is not working for me and I had to edit manually the MPICH machinefile, I'll open an issue.
I had to install bash because in last alpine versions test.sh execution breaks :-/ I don't know why. I'm not good with bash so I fixed doing this.

**With this base image we can only compile now from 3.3 to 4.0.3**