### PR TITLE
Mounted project folder

### DIFF
--- a/cluster/docker-compose.yml
+++ b/cluster/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     image: registry
     ports:
       - "${REGISTRY_PORT}:5000"
+    volumes:
+      - ./project:/project
 
   master:
     image: $REGISTRY_ADDR:$REGISTRY_PORT/$IMAGE_NAME
@@ -14,13 +16,16 @@ services:
       - "${SSH_PORT}:22"
     networks:
       - net
-
+    volumes:
+      - ./project:/project
+      
   worker:
     image: $REGISTRY_ADDR:$REGISTRY_PORT/$IMAGE_NAME
     user: root
     entrypoint: ["mpi_bootstrap", "role=worker", "mpi_master_service_name=master", "mpi_worker_service_name=worker"]
     networks:
       - net
-
+    volumes:
+      - ./project:/project
 networks:
   net:


### PR DESCRIPTION
inside the cluster for quicker edits without having to login to root. Helps with quicker development and restarting the cluster for each edit during testing.